### PR TITLE
Show 'removeElement' button only if allowed

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -17,6 +17,7 @@
           class="multiselect__tag">
             <span v-text="getOptionLabel(option)"></span>
             <i
+              v-show="allowEmpty || internalValue.length > 1"
               aria-hidden="true"
               tabindex="1"
               @keydown.enter.prevent="removeElement(option)"


### PR DESCRIPTION
When clearing an element is not allowed but the 'remove' button is shown, it just doesn't work. This is very confusing for a user who doesn't understand what is going on. It looks like the function is broken. So, instead, let's just not show it!